### PR TITLE
Make web-service-admins owners of the data folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
+
 *  @baltimorecounty/front-end-developers
+
+/data/ @baltimorecounty/web-services-admin


### PR DESCRIPTION
This addresses the [Fix CODEOWNERS for Data Files](https://github.com/baltimorecounty/BaltCoGo/issues/10) issue.
Added web-services-admin team as owners of the data folder.